### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
-# GLSL Webpack loader that support variables and #include directive.
+# GLSL Webpack loader
+
+This loader supports template variables and the `#include` directive.
+
+`#include` will include the entire contents of another glsl file, this happens at compile time and uses webpacks resolver to find the file requested.  The loader will then give you a function where you can supply template variables at runtime.
+
 
 ## Install
-```npm install glsl-template-loader --save-dev```
 
-## Config Webpack
+``` bash
+npm install glsl-template-loader --save-dev
 ```
+
+
+
+## Configuring Webpack
+
+``` js
+resolve: {
+  extensions: ['', '.webpack.js', '.js', '.vert', '.frag', '.glsl']
+},
 module: {
   loaders: [{
     test: /\.(glsl|vert|frag)$/,
@@ -13,42 +27,48 @@ module: {
 },
 // Default values (can be ommited)
 glsl: {
-  chunksPath: './src/chunks', // Path to look chunks at
-  chunksExt: 'glsl', // Chunks extension
   varPrefix: '$' // Every valid name that starts with this symbol will be treated as a template variable
 }
 ```
 
+
+
 ## Write some shaders
-shader.vert
-```
+
+`shaders/shader.vert`
+
+``` glsl
 attribute vec2 a_Position;
 attribute vec3 a_Color;
 
 varying vec3 v_Color;
 
-// The content of chunks/reduce-red.glsl file will be inlined here
-#include reduce-red;
+// The content of shaders/util/reduce-red.glsl file will be inlined here
+#include ./util/reduce-red;
 
 void main(void) {
   v_Color = reduceR(a_Color);
   gl_Position = vec4(a_Position, 0.0, 1.0);
 }
 ```
-shader.frag
-```
+
+`shaders/shader.frag`
+
+``` glsl
 precision highp float;
 
 varying vec3 v_Color;
 
-#include reduce-red;
+#include ./util/reduce-red;
 
 void main() {
   gl_FragColor = vec4(reduceR(v_Color), 0.5);
 }
 ```
-chunks/reduce-red.glsl
-```
+
+`shaders/util/reduce-red.glsl`
+
+``` glsl
 vec3 reduceR(vec3 color) {
   // We arge going to use a template variable $reduce that would be inlined with it's value
   // Note that we use $reduce.0 to transform int values from template to float
@@ -57,23 +77,33 @@ vec3 reduceR(vec3 color) {
 }
 ```
 
+
+
 ## Import your shader templates
-```
+
+es6
+``` js
 import createVertexShader from 'shader.vert';
 import createFragmentShader from 'shader.frag';
 ```
-or
+
+es5
+``` js
+var createVertexShader = require('shader.vert');
+var createFragmentShader = require('shader.frag');
 ```
-const createVertexShader = require('shader.vert');
-const createFragmentShader = require('shader.frag');
-```
+
+
 
 ## Create shaders
-```
+
+``` js
 // That's how we pass our reduce variable to templates
-const vertexShader = createVertexShader({reduce: 5});
-const fragmentShader = createFragmentShader({reduce: 2});
+const vertexShader = createVertexShader({ reduce: 5 });
+const fragmentShader = createFragmentShader({ reduce: 2 });
 ```
 
+
 ## License
+
 [MIT](http://www.opensource.org/licenses/mit-license.php)

--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
     "loader"
   ],
   "homepage": "https://github.com/yuri-karadzhov/glsl-template-loader.git",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "babel-core": "^6.14.0",
+    "babel-preset-es2015": "^6.14.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
   "license": "MIT",
   "dependencies": {
     "babel-core": "^6.14.0",
-    "babel-preset-es2015": "^6.14.0"
+    "babel-preset-es2015": "^6.14.0",
+    "bluebird": "^3.4.6",
+    "chalk": "^1.1.3",
+    "glsl-man": "git+https://github.com/jsio-private/glsl-man#d4178c0b08a9b2e7cab7248994e123561bade1d5"
   },
   "devDependencies": {
     "eslint": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "babel-preset-es2015": "^6.14.0",
     "bluebird": "^3.4.6",
     "chalk": "^1.1.3",
-    "glsl-man": "git+https://github.com/jsio-private/glsl-man#d4178c0b08a9b2e7cab7248994e123561bade1d5"
+    "glsl-man": "git+https://github.com/jsio-private/glsl-man#d4178c0b08a9b2e7cab7248994e123561bade1d5",
+    "left-pad": "^1.1.1"
   },
   "devDependencies": {
     "eslint": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -19,5 +19,11 @@
   "dependencies": {
     "babel-core": "^6.14.0",
     "babel-preset-es2015": "^6.14.0"
+  },
+  "devDependencies": {
+    "eslint": "^3.5.0"
+  },
+  "scripts": {
+    "lint": "eslint index.js"
   }
 }


### PR DESCRIPTION
- Fix es6 param format for use with LTS
- Babel output source for better browser compatibility (template literals are not yet fully adopted)
- Better promise errors by using bluebird
- Better source parsing with glsl-man instead of regex
- Better error logging with chalk
- Proper module resolution using webpack
- Updated Readme
- Sweet error logs (see below)

<img width="519" alt="screenshot 2016-09-22 17 19 57" src="https://cloud.githubusercontent.com/assets/536581/18770289/61e4f0b2-80e9-11e6-892d-f6b0359ceb5c.png">
